### PR TITLE
Add basic Google login

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "editor.formatOnPaste": true, // required
   "editor.formatOnType": false, // required
   "editor.formatOnSave": true, // optional
-  "editor.formatOnSaveMode": "file" // required to format on save
+  "editor.formatOnSaveMode": "file",
+  "typescript.tsdk": "node_modules/typescript/lib" // required to format on save
 }

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,5 +1,6 @@
-import { Box, Container, Stack } from '@chakra-ui/react'
+import { Box, Container, Stack, Button } from '@chakra-ui/react'
 import { DarkMode } from './DarkMode'
+import Link from 'next/link'
 
 export const NavBar = (props:any) => {
   return (
@@ -12,6 +13,7 @@ export const NavBar = (props:any) => {
             flexGrow={1}
             mt={{ base: 5, md: 0 }}/>
         <DarkMode/>
+        <Link href='/api/auth/signin'>Login</Link>
       </Container>
   </Box>
   )

--- a/example.env.local
+++ b/example.env.local
@@ -1,0 +1,4 @@
+NEXTAUTH_SECRET="secret_password_here"
+NEXTAUTH_URL="project_url_here"
+GOOGLE_CLIENT_ID="id_here"
+GOOGLE_CLIENT_SECRET="secret_here"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-config-next": "13.1.1",
         "framer-motion": "^6.5.1",
         "next": "13.1.1",
+        "next-auth": "^4.18.8",
         "postgres": "^3.3.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -2492,6 +2493,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.2.tgz",
+      "integrity": "sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@pkgr/utils": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.1.tgz",
@@ -3113,6 +3122,14 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.1",
@@ -4735,6 +4752,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/jose": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
+      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
@@ -5003,11 +5028,46 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.18.8",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.18.8.tgz",
+      "integrity": "sha512-USP8ihmvB7iCGtkS0+toe2QPrzdbZfkydQZX56JOI9Ft5n/BardOXh3D4wQ2An+vpq/jDKojGlgfv21wVElW7A==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.3",
+        "@panva/hkdf": "^1.0.1",
+        "cookie": "^0.5.0",
+        "jose": "^4.9.3",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.1.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": "^12.19.0 || ^14.15.0 || ^16.13.0 || ^18.12.0"
+      },
+      "peerDependencies": {
+        "next": "^12.2.5 || ^13",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18",
+        "react-dom": "^17.0.2 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "peer": true
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5015,6 +5075,14 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -5122,6 +5190,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
+      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5144,6 +5220,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.3.1.tgz",
+      "integrity": "sha512-RLfehQiHch9N6tRWNx68cicf3b1WR0x74bJWHRc25uYIbSRwjxYcTFaRnzbbpls5jroLAaB/bFIodTgA5LJMvw==",
+      "dependencies": {
+        "jose": "^4.10.0",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -5322,6 +5412,26 @@
         "url": "https://github.com/sponsors/porsager"
       }
     },
+    "node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5344,6 +5454,11 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6114,6 +6229,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint-config-next": "13.1.1",
     "framer-motion": "^6.5.1",
     "next": "13.1.1",
+    "next-auth": "^4.18.8",
     "postgres": "^3.3.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,14 @@
 import theme from '../styles/theme'
 import { ChakraProvider } from '@chakra-ui/react'
 import type { AppProps } from 'next/app'
+import { SessionProvider } from 'next-auth/react'
 
-export default function App({ Component, pageProps }: AppProps) {
+export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
-    <ChakraProvider theme={theme}>
-      <Component {...pageProps} />
-    </ChakraProvider>
-    )
+    <SessionProvider session={session}>
+      <ChakraProvider theme={theme}>
+        <Component {...pageProps} />
+      </ChakraProvider>
+    </SessionProvider>
+  )
 }

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,2 @@
+import NextAuth from 'next-auth'
+import GoogleProvider from 'next-auth/providers/google'

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,2 +1,13 @@
 import NextAuth from 'next-auth'
 import GoogleProvider from 'next-auth/providers/google'
+
+export const authOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET
+    })
+  ]
+}
+
+export default NextAuth(authOptions)

--- a/pages/userAuth.tsx
+++ b/pages/userAuth.tsx
@@ -1,0 +1,20 @@
+import { useSession, signOut } from 'next-auth/react';
+
+// after authorization, user gets redirected to this page by default
+// this probably has to be changed, but can be used for testing purposes for now
+export default function UserAuth() {
+  const { data: session, status } = useSession();
+
+  // status is either loading, authenticated, or unauthenticated
+  console.log('status:', status);
+
+  // session is either null or a session object
+  console.log('session:', session);
+
+  return (
+    <>
+      <h1>Test page</h1>
+      <button onClick={() => signOut()}>Sign out</button>
+    </>
+  );
+}

--- a/process.d.ts
+++ b/process.d.ts
@@ -1,0 +1,8 @@
+declare namespace NodeJS {
+  export interface ProcessEnv {
+    NEXTAUTH_SECRET: string
+    NEXTAUTH_URL: string
+    GOOGLE_CLIENT_ID: string
+    GOOGLE_CLIENT_SECRET: string
+  }
+}


### PR DESCRIPTION
Added next-auth to provide Google OAuth login. There is a basic link in the navbar to redirect users to the signin route. They then get redirected to the `/userAuth` page, which just prints data about the session to the console.
![image](https://user-images.githubusercontent.com/25358856/212492963-47aa73e9-9e3f-4efb-be95-ffd19a44e93a.png)

To setup .env variables, copy `.example.env.local` to `.env.local`. The `NEXTAUTH_SECRET` is a password you can pick to encrypt the JWT stuff (I think). `NEXTAUTH_URL` can just point to localhost (or the deployed url). `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are Google OAuth API keys that you can generate on the [API dashboard](https://console.cloud.google.com/apis/dashboard). If you get errors about authorization, make sure you add localhost to the authorized redirect URIs.